### PR TITLE
df-daemon: change the import path

### DIFF
--- a/src/daemon/src/df-daemon/df-daemon.go
+++ b/src/daemon/src/df-daemon/df-daemon.go
@@ -14,12 +14,14 @@
 package main
 
 import (
-	_ "df-daemon/initializer"
-	"github.com/Sirupsen/logrus"
 	"fmt"
 	"net/http"
 	"runtime"
-	. "df-daemon/global"
+
+	"github.com/Sirupsen/logrus"
+
+	. "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/global"
+	_ "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/initializer"
 )
 
 func main() {
@@ -44,6 +46,3 @@ func main() {
 		logrus.Fatal(err)
 	}
 }
-
-
-

--- a/src/daemon/src/df-daemon/global/global.go
+++ b/src/daemon/src/df-daemon/global/global.go
@@ -16,6 +16,7 @@ package global
 import (
 	"regexp"
 	"sync"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -27,15 +28,15 @@ type CommandParam struct {
 	Urlfilter  string
 	Notbs      bool
 
-	Version    bool
-	Verbose    bool
-	Help       bool
-	Port       uint
-	Registry   string //https://xxx.xx.x:port or http://xxx.xx.x:port
-	DownRule   string
+	Version  bool
+	Verbose  bool
+	Help     bool
+	Port     uint
+	Registry string //https://xxx.xx.x:port or http://xxx.xx.x:port
+	DownRule string
 
-	CertFile   string
-	KeyFile    string
+	CertFile string
+	KeyFile  string
 }
 
 var (
@@ -94,5 +95,3 @@ func MatchDfPattern(location string) bool {
 	}
 	return useGetter
 }
-
-

--- a/src/daemon/src/df-daemon/handler/debug_handler.go
+++ b/src/daemon/src/df-daemon/handler/debug_handler.go
@@ -15,10 +15,12 @@ package handler
 
 import (
 	"net/http"
-	"strings"
 	"net/http/pprof"
-	"df-daemon/constant"
+	"strings"
+
 	"github.com/Sirupsen/logrus"
+
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/constant"
 )
 
 func DebugInfo(w http.ResponseWriter, req *http.Request) {

--- a/src/daemon/src/df-daemon/handler/dfgetter.go
+++ b/src/daemon/src/df-daemon/handler/dfgetter.go
@@ -14,17 +14,19 @@
 package handler
 
 import (
-	"sync"
-	"strings"
-	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"os/exec"
-	. "df-daemon/global"
-	"time"
-	"syscall"
-	"df-daemon/constant"
-	"df-daemon/exception"
 	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/constant"
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/exception"
+	. "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/global"
 )
 
 type Downloader interface {
@@ -35,17 +37,17 @@ type Downloader interface {
 
 type DFgetter struct {
 	//output dir
-	dstDir     string
+	dstDir string
 	//the urlfilter param of dfget
-	urlFilter  string
+	urlFilter string
 	//the totallimit and s param of dfget
-	rateLimit  string
+	rateLimit string
 	//the callsystem param of dfget
 	callSystem string
 	//the notbs param of dfget
-	notbs      bool
+	notbs bool
 
-	once       sync.Once
+	once sync.Once
 }
 
 var getter = new(DFgetter)
@@ -57,7 +59,7 @@ func (dfgetter *DFgetter) Download(url string, header map[string][]string, name 
 	_, err := cmd.CombinedOutput()
 
 	if cmd.ProcessState.Success() {
-		log.Infof("dfget url:%s [SUCCESS] cost:%ds", url, time.Now().Unix() - startTime)
+		log.Infof("dfget url:%s [SUCCESS] cost:%ds", url, time.Now().Unix()-startTime)
 		return dstPath, nil
 	} else {
 		if value, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
@@ -72,7 +74,7 @@ func (dfgetter *DFgetter) Download(url string, header map[string][]string, name 
 func (dfgetter *DFgetter) parseCommand(url string, header map[string][]string, name string) (cmdPath string, args []string, dstPath string) {
 	args = make([]string, 0, 32)
 	args = append(append(args, "-u"), url)
-	args = append(append(args, "-o"), getter.dstDir + name)
+	args = append(append(args, "-o"), getter.dstDir+name)
 	if getter.notbs {
 		args = append(args, "--notbs")
 	}
@@ -120,5 +122,3 @@ func DownloadByGetter(url string, header map[string][]string, name string) (stri
 	})
 	return getter.Download(url, header, name)
 }
-
-

--- a/src/daemon/src/df-daemon/handler/env_handler.go
+++ b/src/daemon/src/df-daemon/handler/env_handler.go
@@ -14,10 +14,12 @@
 package handler
 
 import (
-	"net/http"
-	"df-daemon/global"
 	"fmt"
+	"net/http"
+
 	"github.com/Sirupsen/logrus"
+
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/global"
 )
 
 func GetEnv(w http.ResponseWriter, r *http.Request) {

--- a/src/daemon/src/df-daemon/handler/param_handler.go
+++ b/src/daemon/src/df-daemon/handler/param_handler.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"net/http"
 	"os"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -31,5 +32,3 @@ func GetArgs(w http.ResponseWriter, r *http.Request) {
 
 	}
 }
-
-

--- a/src/daemon/src/df-daemon/handler/root_handler.go
+++ b/src/daemon/src/df-daemon/handler/root_handler.go
@@ -15,11 +15,13 @@ package handler
 
 import (
 	"net/http"
-	"net/url"
 	"net/http/httputil"
-	"df-daemon/util"
-	. "df-daemon/global"
+	"net/url"
+
 	log "github.com/Sirupsen/logrus"
+
+	. "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/global"
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/util"
 )
 
 func Process(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +72,3 @@ func Process(w http.ResponseWriter, r *http.Request) {
 
 	reverseProxy.ServeHTTP(w, r)
 }
-
-
-

--- a/src/daemon/src/df-daemon/initializer/initializer.go
+++ b/src/daemon/src/df-daemon/initializer/initializer.go
@@ -14,23 +14,25 @@
 package util
 
 import (
-	"os"
-	"path/filepath"
-	log "github.com/Sirupsen/logrus"
-	"strings"
-	"os/user"
 	"flag"
-	"time"
+	"fmt"
 	"io"
 	"io/ioutil"
-	"regexp"
+	"os"
 	"os/exec"
-	"fmt"
+	"os/user"
+	"path/filepath"
 	"reflect"
-	"df-daemon/constant"
-	. "df-daemon/muxconf"
-	"df-daemon/util"
-	. "df-daemon/global"
+	"regexp"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/constant"
+	. "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/global"
+	. "github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/muxconf"
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/util"
 )
 
 func init() {
@@ -69,7 +71,7 @@ func cleanLocalRepo() {
 						log.Warnf("walk file:%s error:%v", path, err)
 					} else {
 						if info.Mode().IsRegular() {
-							if time.Now().Unix() - reflect.ValueOf(info.Sys()).Elem().FieldByName("Atim").Field(0).Int() >= 3600 {
+							if time.Now().Unix()-reflect.ValueOf(info.Sys()).Elem().FieldByName("Atim").Field(0).Int() >= 3600 {
 								if err := os.Remove(path); err == nil {
 									log.Infof("remove file:%s success", path)
 								} else {
@@ -95,7 +97,7 @@ func rotateLog(logFile *os.File, logFilePath string) {
 					log.SetOutput(ioutil.Discard)
 					logFile.Sync()
 					if transFile, err := os.Open(logFilePath); err == nil {
-						transFile.Seek(-10 * 1024 * 1024, 2)
+						transFile.Seek(-10*1024*1024, 2)
 						logFile.Seek(0, 0)
 						count, _ := io.Copy(logFile, transFile)
 						logFile.Truncate(count)
@@ -123,9 +125,9 @@ func initLogger() {
 	}
 
 	logFilePath := G_HomeDir + ".small-dragonfly/logs/dfdaemon.log"
-	log.SetFormatter(&log.TextFormatter{TimestampFormat:"2006-01-02 15:04:00", DisableColors:true})
+	log.SetFormatter(&log.TextFormatter{TimestampFormat: "2006-01-02 15:04:00", DisableColors: true})
 	if os.MkdirAll(filepath.Dir(logFilePath), 0755) == nil {
-		if logFile, err := os.OpenFile(logFilePath, os.O_CREATE | os.O_RDWR, 0644); err == nil {
+		if logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_RDWR, 0644); err == nil {
 			logFile.Seek(0, 2)
 			log.SetOutput(logFile)
 			go rotateLog(logFile, logFilePath)
@@ -135,7 +137,7 @@ func initLogger() {
 }
 
 func initParam() {
-	flag.StringVar(&G_CommandLine.DFRepo, "localrepo", G_HomeDir + ".small-dragonfly/dfdaemon/data/", "temp output dir of daemon")
+	flag.StringVar(&G_CommandLine.DFRepo, "localrepo", G_HomeDir+".small-dragonfly/dfdaemon/data/", "temp output dir of daemon")
 
 	var defaultPath string
 	if path, err := exec.LookPath(os.Args[0]); err == nil {
@@ -207,7 +209,7 @@ func initParam() {
 		os.Exit(constant.CODE_EXIT_DFGET_NOT_FOUND)
 	}
 	cmd := exec.Command(G_CommandLine.DfPath, "-v")
-	version, _ := cmd.CombinedOutput();
+	version, _ := cmd.CombinedOutput()
 
 	log.Infof("dfget version:%s", string(version))
 
@@ -224,7 +226,7 @@ func initParam() {
 		protoAndDomain := strings.SplitN(G_CommandLine.Registry, "://", 2)
 		splitedCount := len(protoAndDomain)
 		G_RegProto = "http"
-		G_RegDomain = protoAndDomain[splitedCount - 1]
+		G_RegDomain = protoAndDomain[splitedCount-1]
 		if splitedCount == 2 {
 			G_RegProto = protoAndDomain[0]
 		}

--- a/src/daemon/src/df-daemon/muxconf/muxconf.go
+++ b/src/daemon/src/df-daemon/muxconf/muxconf.go
@@ -13,19 +13,21 @@
 // limitations under the License.
 package muxconf
 
-import . "net/http"
-import "df-daemon/handler"
+import (
+	"net/http"
+
+	"github.com/alibaba/Dragonfly/src/daemon/src/df-daemon/handler"
+)
 
 func InitMux() {
-	router := map[string]func(ResponseWriter, *Request){
-		"/":handler.Process,
-		"/args": handler.GetArgs,
-		"/debug/":handler.DebugInfo,
-		"/env":handler.GetEnv,
+	router := map[string]func(http.ResponseWriter, *http.Request){
+		"/":       handler.Process,
+		"/args":   handler.GetArgs,
+		"/debug/": handler.DebugInfo,
+		"/env":    handler.GetEnv,
 	}
 
 	for key, value := range router {
-		HandleFunc(key, value)
+		http.HandleFunc(key, value)
 	}
 }
-

--- a/src/daemon/src/df-daemon/util/netutil.go
+++ b/src/daemon/src/df-daemon/util/netutil.go
@@ -14,16 +14,18 @@
 package util
 
 import (
-	"net"
-	"strings"
-	"os/exec"
-	"os"
 	"bufio"
-	log "github.com/Sirupsen/logrus"
+	"net"
+	"os"
+	"os/exec"
 	"regexp"
-	"strconv"
 	"runtime"
+	"strconv"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
+
 //ParseInterfaceLimit parse speed of interface that it has prefix of eth
 func NetLimit() string {
 	defer func() {
@@ -77,12 +79,10 @@ func NetLimit() string {
 				}
 			}
 			if maxInterfaceLimit > 0 {
-				return strconv.FormatUint(maxInterfaceLimit / 8, 10) + "M"
+				return strconv.FormatUint(maxInterfaceLimit/8, 10) + "M"
 			}
 		}
 	}
 	return "20M"
 
 }
-
-


### PR DESCRIPTION
basically, as a go project, it should be discoverable by go tools,
thus I makde a change to update its import path to be:

  github.com/alibaba/Dragonfly/src/daemon/src/df-daemon

with this change, you can run:

  go get github.com/alibaba/Dragonfly/src/daemon/src/df-daemon

and get a compiled binary in your $GOPATH/bin.