### PR TITLE
bugfix: report successful piece always gets an error

### DIFF
--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/controller/PeerController.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/controller/PeerController.java
@@ -121,7 +121,7 @@ public class PeerController {
             String taskId = req.getTaskId();
             String cid = req.getCid();
             String dstCid = req.getDstCid();
-            String range = req.getRange();
+            String range = req.getPieceRange();
 
             if (StringUtils.isBlank(taskId) || StringUtils.isBlank(cid)
                 || StringUtils.isBlank(range)) {

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/controller/PeerController.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/controller/PeerController.java
@@ -67,8 +67,9 @@ public class PeerController {
 
     @PostMapping(value = "/registry")
     public ResultInfo doRegistry( RegistryRequest req) {
+        ResultInfo res = null;
         try {
-            return peerRegistryService.registryTask(req.getRawUrl(),
+            res = peerRegistryService.registryTask(req.getRawUrl(),
                 req.getTaskUrl(),
                 req.getMd5(),
                 req.getIdentifier(),
@@ -81,42 +82,47 @@ public class PeerController {
                 req.isDfdaemon());
         } catch (ValidateException e) {
             log.error("param is illegal", e);
-            return new ResultInfo(e.getCode(), e.getMessage(), null);
+            res = new ResultInfo(e.getCode(), e.getMessage(), null);
         } catch (Exception e) {
             log.error("E_registry", e);
-            return new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
+            res = new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
         }
+        debug("doRegistry", req, res);
+        return res;
     }
 
     @GetMapping(value = "/task")
     public ResultInfo pullPieceTask(PullPieceTaskRequest req) {
+        ResultInfo res = null;
         long start = System.currentTimeMillis();
         try {
-            ResultInfo processResult = commonPeerDispatcher.process(
+            res = commonPeerDispatcher.process(
                 req.getSrcCid(),
                 req.getDstCid(),
                 req.getTaskId(),
                 req.getRange(),
                 req.getResult(),
                 req.getStatus());
-            if (processResult == null) {
-                processResult = new ResultInfo(ResultCode.SYSTEM_ERROR, JSON.toJSONString(req), null);
+            if (res == null) {
+                res = new ResultInfo(ResultCode.SYSTEM_ERROR, JSON.toJSONString(req), null);
             }
             long end = System.currentTimeMillis();
             if (end - start > 1000) {
                 log.warn("do peer task cost:{}ms", end - start);
             }
-            return processResult;
         } catch (ValidateException e) {
-            return new ResultInfo(e.getCode(), e.getMessage(), null);
+            res = new ResultInfo(e.getCode(), e.getMessage(), null);
         } catch (Exception e) {
             log.error("E_PeerTaskServlet", e);
-            return new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
+            res = new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
         }
+        debug("pullPieceTask", req, res);
+        return res;
     }
 
     @GetMapping(value = "/piece/suc")
     public ResultInfo reportPiece(ReportPieceRequest req) {
+        ResultInfo res = null;
         try {
             String taskId = req.getTaskId();
             String cid = req.getCid();
@@ -125,29 +131,31 @@ public class PeerController {
 
             if (StringUtils.isBlank(taskId) || StringUtils.isBlank(cid)
                 || StringUtils.isBlank(range)) {
-                return new ResultInfo(ResultCode.PARAM_ERROR,
+                res = new ResultInfo(ResultCode.PARAM_ERROR,
                     "some param is empty", null);
-            }
-            int pieceNum = RangeParseUtil.calculatePieceNum(range);
-            ResultInfo resultInfo = null;
-            if (pieceNum >= 0) {
-                resultInfo = progressService.updateProgress(taskId, cid,
-                    dstCid, pieceNum, PeerPieceStatus.SUCCESS);
             } else {
-                log.error("do piece suc fail for cid:{} pieceNum:{}", cid,
-                    pieceNum);
+                int pieceNum = RangeParseUtil.calculatePieceNum(range);
+                if (pieceNum >= 0) {
+                    res = progressService.updateProgress(taskId, cid,
+                        dstCid, pieceNum, PeerPieceStatus.SUCCESS);
+                } else {
+                    log.error("do piece suc fail for cid:{} pieceNum:{}", cid,
+                        pieceNum);
+                }
+                if (res == null) {
+                    res = new ResultInfo(ResultCode.SYSTEM_ERROR);
+                }
             }
-            if (resultInfo == null) {
-                resultInfo = new ResultInfo(ResultCode.SYSTEM_ERROR);
-            }
-            return resultInfo;
         } catch (Exception e) {
-            return new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
+            res = new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
         }
+        debug("reportPiece", req, res);
+        return res;
     }
 
     @GetMapping(value = "/service/down")
     public ResultInfo reportServiceDown(ReportServiceDownRequest req) {
+        ResultInfo res = null;
         try {
             String cid = req.getCid();
             String taskId = req.getTaskId();
@@ -158,9 +166,17 @@ public class PeerController {
                 lockService.unlockTaskOnRead(taskId);
             }
 
-            return new ResultInfo(ResultCode.SUCCESS);
+            res = new ResultInfo(ResultCode.SUCCESS);
         } catch (Exception e) {
-            return new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
+            res = new ResultInfo(ResultCode.SYSTEM_ERROR, e.getMessage(), null);
+        }
+        debug("reportServiceDown", req, res);
+        return res;
+    }
+
+    private void debug(String msg, Object req, ResultInfo res) {
+        if (log.isDebugEnabled()) {
+            log.debug("{}, req: {} res: {}", msg, JSON.toJSONString(req), JSON.toJSON(res));
         }
     }
 }

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/request/ReportPieceRequest.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/rest/request/ReportPieceRequest.java
@@ -28,5 +28,5 @@ public class ReportPieceRequest {
     private String taskId;
     private String cid;
     private String dstCid;
-    private String range;
+    private String pieceRange;
 }


### PR DESCRIPTION
dfget query supernode's api `/peer/piece/suc` always gets an error: `some param is empty`. The error is caused by inconsistent parameter name `range` between supernode and dfget.

And this pull request will do:
* bugfix: inconsistent parameter name "range" of report piece success request between supernode and dfget
* log: add debug logs for PeerController

Please merge to branch `master` and `0.1.x`.