### PR TITLE
fix(dfdaemon): fix default value of options.DFRepo

### DIFF
--- a/cmd/dfdaemon/options/options.go
+++ b/cmd/dfdaemon/options/options.go
@@ -41,7 +41,7 @@ func New() *Options {
 	}
 
 	o := &Options{
-		DFRepo:     os.Getenv("HOME") + ".small-dragonfly/dfdaemon/data/",
+		DFRepo:     filepath.Join(os.Getenv("HOME"), ".small-dragonfly/dfdaemon/data/"),
 		DfPath:     defaultPath,
 		CallSystem: "com_ops_dragonfly",
 		URLFilter:  "Signature&Expires&OSSAccessKeyId",


### PR DESCRIPTION
Start dfdaemon failed because of the invalid default value of options.DFRepo: `$HOME.small-dragonfly/dfdaemon/data/`. The expected value is: `$HOME/.small-dragonfly/dfdaemon/data/`.
Missed a `/` between `$HOME` and `.small-dragonfly`.