### PR TITLE
feature: add blocking queue

### DIFF
--- a/dfget/util/queue.go
+++ b/dfget/util/queue.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright 1999-2018 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"container/list"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// Queue blocking queue. The items putted into queue mustn't be nil.
+type Queue interface {
+	// Put puts item into the queue and blocking if the queue is full.
+	// It will return immediately and do nothing if the item is nil.
+	Put(item interface{})
+
+	// PutTimeout puts item into the queue and wait for timeout if the queue is full.
+	// If timeout <= 0, it will returns false immediately when queue is full.
+	// It will return immediately and do nothing if the item is nil.
+	PutTimeout(item interface{}, timeout time.Duration) bool
+
+	// Poll get an item from the queue and blocking if the queue is empty.
+	Poll() interface{}
+
+	// PollTimeout get an item from the queue and wait for timeout if the queue is empty.
+	// If timeout <= 0, it will returns (nil, bool) immediately when queue is empty.
+	PollTimeout(timeout time.Duration) (interface{}, bool)
+
+	// Len returns the current size of the queue.
+	Len() int
+}
+
+// NewQueue creates a blocking queue.
+// If capacity <= 0, the queue capacity is infinite.
+func NewQueue(capacity int) Queue {
+	if capacity <= 0 {
+		c := make(chan struct{})
+		return &infiniteQueue{
+			store: list.New(),
+			empty: unsafe.Pointer(&c),
+		}
+	}
+	return &finiteQueue{
+		store: make(chan interface{}, capacity),
+	}
+}
+
+// infiniteQueue implements infinite blocking queue.
+type infiniteQueue struct {
+	sync.Mutex
+	store *list.List
+	empty unsafe.Pointer
+}
+
+func (q *infiniteQueue) Put(item interface{}) {
+	if IsNil(item) {
+		return
+	}
+	q.Lock()
+	defer q.Unlock()
+	q.store.PushBack(item)
+	if q.store.Len() < 2 {
+		// empty -> has one element
+		q.broadcast()
+	}
+}
+
+func (q *infiniteQueue) PutTimeout(item interface{}, timeout time.Duration) bool {
+	q.Put(item)
+	return !IsNil(item)
+}
+
+func (q *infiniteQueue) Poll() interface{} {
+	q.Lock()
+	defer q.Unlock()
+	for q.store.Len() == 0 {
+		q.wait()
+	}
+	item := q.store.Front()
+	q.store.Remove(item)
+	return item.Value
+}
+
+func (q *infiniteQueue) PollTimeout(timeout time.Duration) (interface{}, bool) {
+	deadline := time.Now().Add(timeout)
+	q.Lock()
+	defer q.Unlock()
+	for q.store.Len() == 0 {
+		timeout = -time.Since(deadline)
+		if timeout <= 0 || !q.waitTimeout(timeout) {
+			return nil, false
+		}
+	}
+	item := q.store.Front()
+	q.store.Remove(item)
+	return item.Value, true
+}
+
+func (q *infiniteQueue) Len() int {
+	q.Lock()
+	defer q.Unlock()
+	return q.store.Len()
+}
+
+func (q *infiniteQueue) wait() {
+	c := q.notifyChan()
+	q.Unlock()
+	defer q.Lock()
+	<-c
+}
+
+func (q *infiniteQueue) waitTimeout(timeout time.Duration) bool {
+	c := q.notifyChan()
+
+	q.Unlock()
+	defer q.Lock()
+	select {
+	case <-c:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (q *infiniteQueue) notifyChan() <-chan struct{} {
+	ptr := atomic.LoadPointer(&q.empty)
+	return *((*chan struct{})(ptr))
+}
+
+// broadcast notify all the Poll goroutines to re-check the queue whether is empty.
+func (q *infiniteQueue) broadcast() {
+	c := make(chan struct{})
+	old := atomic.SwapPointer(&q.empty, unsafe.Pointer(&c))
+	close(*(*chan struct{})(old))
+}
+
+// finiteQueue implements finite blocking queue by buffered channels.
+type finiteQueue struct {
+	store chan interface{}
+}
+
+func (q *finiteQueue) Put(item interface{}) {
+	if IsNil(item) {
+		return
+	}
+	q.store <- item
+}
+
+func (q *finiteQueue) PutTimeout(item interface{}, timeout time.Duration) bool {
+	if IsNil(item) {
+		return false
+	}
+	if timeout <= 0 {
+		select {
+		case q.store <- item:
+			return true
+		default:
+			return false
+		}
+	}
+	select {
+	case q.store <- item:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (q *finiteQueue) Poll() interface{} {
+	item := <-q.store
+	return item
+}
+
+func (q *finiteQueue) PollTimeout(timeout time.Duration) (interface{}, bool) {
+	if timeout <= 0 {
+		select {
+		case item := <-q.store:
+			return item, true
+		default:
+			return nil, false
+		}
+	}
+	select {
+	case item := <-q.store:
+		return item, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+func (q *finiteQueue) Len() int {
+	return len(q.store)
+}

--- a/dfget/util/queue.go
+++ b/dfget/util/queue.go
@@ -143,7 +143,7 @@ func (q *infiniteQueue) notifyChan() <-chan struct{} {
 	return *((*chan struct{})(ptr))
 }
 
-// broadcast notify all the Poll goroutines to re-check the queue whether is empty.
+// broadcast notify all the Poll goroutines to re-check whether the queue is empty.
 func (q *infiniteQueue) broadcast() {
 	c := make(chan struct{})
 	old := atomic.SwapPointer(&q.empty, unsafe.Pointer(&c))

--- a/dfget/util/queue_test.go
+++ b/dfget/util/queue_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 1999-2018 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-check/check"
+)
+
+func (suite *DFGetUtilSuite) TestQueue_infiniteQueue(c *check.C) {
+	timeout := 50 * time.Millisecond
+	q := NewQueue(0)
+
+	q.Put(nil)
+	c.Assert(q.Len(), check.Equals, 0)
+
+	q.PutTimeout(nil, 0)
+	c.Assert(q.Len(), check.Equals, 0)
+
+	q.Put(0)
+	c.Assert(q.Len(), check.Equals, 1)
+	c.Assert(q.Poll(), check.Equals, 0)
+	c.Assert(q.Len(), check.Equals, 0)
+
+	{ // test Poll
+		time.AfterFunc(timeout, func() { q.Put(1) })
+		start := time.Now()
+		c.Assert(q.Poll(), check.Equals, 1)
+		c.Assert(time.Since(start) > timeout, check.Equals, true)
+	}
+
+	{ // test PollTimeout
+		v, ok := q.PollTimeout(0)
+		c.Assert(v, check.IsNil)
+		c.Check(ok, check.Equals, false)
+
+		start := time.Now()
+		v, ok = q.PollTimeout(timeout)
+		c.Assert(v, check.IsNil)
+		c.Check(ok, check.Equals, false)
+		c.Assert(time.Since(start) > timeout, check.Equals, true)
+
+		time.AfterFunc(timeout/2, func() { q.Put(1) })
+		start = time.Now()
+		v, ok = q.PollTimeout(timeout)
+		c.Assert(ok, check.Equals, true)
+		c.Assert(v, check.Equals, 1)
+		c.Assert(time.Since(start) >= timeout/2, check.Equals, true)
+		c.Assert(time.Since(start) < timeout, check.Equals, true)
+	}
+}
+func (suite *DFGetUtilSuite) TestQueue_infiniteQueue_PollTimeout(c *check.C) {
+	timeout := 50 * time.Millisecond
+	q := NewQueue(0)
+
+	wg := sync.WaitGroup{}
+	var cnt int32
+	f := func(i int) {
+		if _, ok := q.PollTimeout(timeout); ok {
+			atomic.AddInt32(&cnt, 1)
+		}
+		wg.Done()
+	}
+	start := time.Now()
+	n := 6
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go f(i)
+	}
+	time.AfterFunc(timeout/2, func() {
+		for i := 0; i < n-1; i++ {
+			q.Put(i)
+		}
+	})
+	wg.Wait()
+
+	c.Assert(time.Since(start) > timeout, check.Equals, true)
+	c.Assert(cnt, check.Equals, int32(n-1))
+}
+
+func (suite *DFGetUtilSuite) TestQueue_finiteQueue(c *check.C) {
+	timeout := 50 * time.Millisecond
+	q := NewQueue(2)
+
+	q.Put(nil)
+	c.Assert(q.Len(), check.Equals, 0)
+
+	q.PutTimeout(nil, 0)
+	c.Assert(q.Len(), check.Equals, 0)
+
+	q.Put(1)
+	c.Assert(q.Len(), check.Equals, 1)
+
+	start := time.Now()
+	q.PutTimeout(2, timeout)
+	q.PutTimeout(3, timeout)
+	q.PutTimeout(4, 0)
+	c.Assert(q.Len(), check.Equals, 2)
+	c.Assert(time.Since(start) >= timeout, check.Equals, true)
+	c.Assert(time.Since(start) < 2*timeout, check.Equals, true)
+
+	c.Assert(q.Poll(), check.Equals, 1)
+	c.Assert(q.Len(), check.Equals, 1)
+	c.Assert(q.Poll(), check.Equals, 2)
+
+	{
+		q.PutTimeout(1, 0)
+		item, ok := q.PollTimeout(timeout)
+		c.Assert(ok, check.Equals, true)
+		c.Assert(item, check.Equals, 1)
+
+		start = time.Now()
+		item, ok = q.PollTimeout(timeout)
+		c.Assert(ok, check.Equals, false)
+		c.Assert(item, check.IsNil)
+		c.Assert(time.Since(start) >= timeout, check.Equals, true)
+
+		start = time.Now()
+		q.PutTimeout(1, 0)
+		item, ok = q.PollTimeout(0)
+		c.Assert(ok, check.Equals, true)
+		c.Assert(item, check.Equals, 1)
+		item, ok = q.PollTimeout(0)
+		c.Assert(ok, check.Equals, false)
+		c.Assert(item, check.IsNil)
+		c.Assert(time.Since(start) < timeout, check.Equals, true)
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add a general implementation of blocking queue to use easily instead of directly using buffered channels.

The buffered channels can only implement blocking queue with a fixed capacity and there're many redundant codes when we directly use it.

So this pull request defines a general blocking queue interface and implements 2 kinds of blocking queue:
* `infiniteQueue`: we can use it when we don't care about the capacity of queue beforehand. It uses `List` to store elements, uses a `unsafe.Pointer(point to a chan)` and `sync.Mutex` for concurrency controlling.
    ```go
    // create a blocking queue with an infinite capacity
    q := NewQueue(0)
    ```
* `finiteQueue`: we can use it when we want a fixed capacity queue. It's implemented by buffered channels.
    ```go
    // create a blocking queue with fixed capacity
    q := NewQueue(10)
    ```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


