### PR TITLE
bugfix: md5 not match after downloading

### DIFF
--- a/dfget/core/downloader/back_downloader_test.go
+++ b/dfget/core/downloader/back_downloader_test.go
@@ -85,6 +85,12 @@ func (s *BackDownloaderTestSuite) TestBackDownloader_Run(c *check.C) {
 	md5sum := util.Md5Sum(dst)
 	c.Assert(testFileMd5, check.Equals, md5sum)
 
+	// test: realMd5 doesn't equal to expectedMd5
 	bd.Md5 = "x"
 	c.Assert(bd.Run(), check.NotNil)
+
+	// test: realMd5 equals to expectedMd5
+	bd.cleaned = false
+	bd.Md5 = testFileMd5
+	c.Assert(bd.Run(), check.IsNil)
 }

--- a/dfget/core/downloader/limit_reader.go
+++ b/dfget/core/downloader/limit_reader.go
@@ -53,13 +53,15 @@ type LimitReader struct {
 
 func (lr *LimitReader) Read(p []byte) (n int, err error) {
 	n, e := lr.Src.Read(p)
-	if e != nil {
+	if e != nil && e != io.EOF {
 		return n, e
 	}
-	if lr.md5sum != nil {
-		lr.md5sum.Write(p[:n])
+	if n > 0 {
+		if lr.md5sum != nil {
+			lr.md5sum.Write(p[:n])
+		}
+		lr.Limiter.AcquireBlocking(int32(n))
 	}
-	lr.Limiter.AcquireBlocking(int32(n))
 	return n, e
 }
 


### PR DESCRIPTION

### Ⅰ. Describe what this PR did

root cause: it's not computing the last bytes before the EOF

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#169 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


