### PR TITLE
fix http cache miss for servers which supports etag only

### DIFF
--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/common/domain/FileMetaData.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/common/domain/FileMetaData.java
@@ -30,6 +30,7 @@ public class FileMetaData {
     private long accessTime;
 
     private long lastModified;
+    private String eTag;
     private boolean finish;
     private boolean success;
     /**
@@ -140,5 +141,13 @@ public class FileMetaData {
 
     public void setPieceSize(Integer pieceSize) {
         this.pieceSize = pieceSize;
+    }
+
+    public String getETag() {
+        return eTag;
+    }
+
+    public void setETag(String eTag) {
+        this.eTag = eTag;
     }
 }

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/CacheDetectorImpl.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/CacheDetectorImpl.java
@@ -113,8 +113,8 @@ public class CacheDetectorImpl implements CacheDetector {
     }
 
     private int parseBreakNum(Task task, FileMetaData fileMetaData) throws MalformedURLException {
-        if (fileMetaData.getLastModified() >= 0
-            && HttpClientUtil.isExpired(task.getSourceUrl(), fileMetaData.getLastModified(), task.getHeaders())) {
+        // both lastModified and eTag not satisfy
+        if (HttpClientUtil.isExpired(task.getSourceUrl(), fileMetaData.getLastModified(), fileMetaData.getETag(), task.getHeaders())) {
             return 0;
         }
 

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/Downloader.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/Downloader.java
@@ -230,7 +230,7 @@ public class Downloader implements Callable<Boolean> {
                         }
                     }
                     if (code == checkCode) {
-                        fileMetaDataService.updateLastModified(taskId, conn.getLastModified());
+                        fileMetaDataService.updateLastModifiedAndETag(taskId, conn.getLastModified(), conn.getHeaderField("ETag"));
                         isConnected = true;
                         break;
                     }

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/FileMetaDataService.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/cdn/FileMetaDataService.java
@@ -29,7 +29,7 @@ public interface FileMetaDataService {
 
     boolean updateAccessTime(String taskId, long accessTime);
 
-    boolean updateLastModified(String taskId, long lastModified);
+    boolean updateLastModifiedAndETag(String taskId, long lastModified, String eTag);
 
     boolean updateStatusAndResult(String taskId, boolean finish, boolean success, String realMd5, Long fileLength);
 

--- a/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/impl/FileMetaDataServiceImpl.java
+++ b/src/supernode/src/main/java/com/alibaba/dragonfly/supernode/service/impl/FileMetaDataServiceImpl.java
@@ -116,7 +116,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     }
 
     @Override
-    public boolean updateLastModified(String taskId, long lastModified) {
+    public boolean updateLastModifiedAndETag(String taskId, long lastModified, String eTag) {
         String lockName = lockService.getLockName(LockConstants.FILE_META_DATA_LOCK, taskId);
         lockService.lock(lockName);
         try {
@@ -124,11 +124,12 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             FileMetaData metaData = readMetaDataByUnlock(metaPath);
             if (metaData != null) {
                 metaData.setLastModified(lastModified);
+                metaData.setETag(eTag);
                 Files.write(metaPath, JSON.toJSONBytes(metaData));
                 return true;
             }
         } catch (Exception e) {
-            logger.error("E_updateLastModified taskId:{}", taskId, e);
+            logger.error("E_updateLastModifiedAndETag taskId:{}", taskId, e);
         } finally {
             lockService.unlock(lockName);
         }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

I used harbor as our docker registry, with Dragonfly as a p2p proxy, and I found that supernode has never hit the cache in `./repo/download`. 

It seems that supernode always downloads the blob file again from harbor, even the same file has exist in the `./repo/download/{taskid}/files`

In the method `CacheDetectorImpl.parseBreakNum`, supernode only uses the `Last-Modified` to check whether the cache has expired.

However, Harbor only returns the `ETag` header in the response message. The `ETag` is the sha256 digest of the blob. 

This PR adds support for ETag identifier with http cache. `parseBreakNum` will return 0 when both `Last-Modified` and `Etag` check failed.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NA

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

NA

### Ⅳ. Describe how to verify it

1. use Harbor as docker registry(I don't think harbor is nessary, however I have not tried), and Dragonfly as a p2p proxy.
2. `docker pull` a image from harbor on a node. check the `app.log` on supernode, will find that supernode download the blob file from harbor.
3. wait 3-6 minites, check `data-gc.log` on supernode, when it says supernode has gc all count, `docker pull` the image again.
4. check the `app.log` on supernode, will get `cache full hit for taskId: ...`. That means the cache hits.

### Ⅴ. Special notes for reviews

NA
