### PR TITLE
chore: fix go vet check failure and misspell of shell scripts

### DIFF
--- a/build/client/run.sh
+++ b/build/client/run.sh
@@ -92,7 +92,7 @@ dfget() {
     dfgetDir="${BIN_DIR}/${PKG_NAME}"
     createDir "${dfgetDir}"
     cp -r "${BUILD_SOURCE_HOME}/src/getter/*" "${dfgetDir}"
-    find "${dfgetDir}" -name '*.pyc' | xargs rm -f
+    find "${dfgetDir}" -name '*.pyc' -exec rm -f {} \;
     chmod a+x "${dfgetDir}/dfget"
 }
 
@@ -110,7 +110,8 @@ unit-test() {
     go test -i ./...
 
     cmd="go list ./... | grep 'github.com/alibaba/Dragonfly/'"
-    sources=$(echo ${GO_SOURCE_DIRECTORIES[@]} | sed 's/ /|/g')
+    sources="${GO_SOURCE_DIRECTORIES[*]}"
+    sources="${sources// /|}"
     test -n "${sources}" && cmd+=" | grep -E '${sources}'"
 
     for d in $(eval "${cmd}")

--- a/build/client/run.sh
+++ b/build/client/run.sh
@@ -76,7 +76,7 @@ check() {
     # go vet check
     echo "CHECK: go vet, check code syntax"
     packages=$(go list ./... | grep -vE "${exclude}" | sed 's/^_//')
-    go vet "${packages}" 2>&1
+    echo "${packages}" | xargs go vet 2>&1
 }
 
 dfdaemon() {
@@ -170,7 +170,6 @@ usage() {
 
 main() {
     cmd="${COMMANDS}"
-    export action=$(echo ${cmd} | grep -w "$1")
     test -z "$1" && usage
     $1
 }

--- a/build/supernode/supernode-build.sh
+++ b/build/supernode/supernode-build.sh
@@ -46,8 +46,10 @@ buildDockerImage() {
 }
 
 check() {
-    which docker > /dev/null && docker ps > /dev/null 2>&1 \
-        || (echo "Please install docker and start docker daemon first." && exit 3)
+    which docker > /dev/null && docker ps > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "Please install docker and start docker daemon first." && exit 3
+    fi
 }
 
 main() {


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

### Ⅰ. Describe what this PR did
> go vet "${packages}" 2>&1

The `"${packages}"` will be treated as one whole string parameter by `go vet`. Actually we want `go vet` receives all files not one file. A workaround is:

```bash
echo "${packages}" | xargs go vet 2>&1
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


