### PR TITLE
feature: add preheat client sdk for supernode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+var (
+	defaultHost    string
+	defaultTimeout = time.Second * 10
+	// defaultVersion is the version of the current stable API
+	defaultVersion = "v1.24"
+)
+
+// APIClient is a API client that performs all operations
+// against a server
+type APIClient struct {
+	proto   string // socket type
+	addr    string
+	baseURL string
+	HTTPCli *http.Client
+	// version of the server talks to
+	version string
+}
+
+// TLSConfig contains information of tls which users can specify
+type TLSConfig struct {
+	CA               string `json:"tlscacert,omitempty"`
+	Cert             string `json:"tlscert,omitempty"`
+	Key              string `json:"tlskey,omitempty"`
+	VerifyRemote     bool   `json:"tlsverify,omitempty"`
+	ManagerWhiteList string `json:"manager-whitelist,omitempty"`
+}
+
+// NewAPIClient initializes a new API client for the given host
+func NewAPIClient(host string, tls TLSConfig) (CommonAPIClient, error) {
+	if host == "" {
+		host = defaultHost
+	}
+
+	newURL, _, addr, err := ParseHost(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse host %s: %v", host, err)
+	}
+
+	tlsConfig := generateTLSConfig(host, tls)
+
+	httpCli := NewHTTPClient(newURL, tlsConfig, defaultTimeout)
+
+	basePath := generateBaseURL(newURL, tls)
+
+	version := os.Getenv("DRAGONFLY_API_VERSION")
+	if version == "" {
+		version = defaultVersion
+	}
+
+	return &APIClient{
+		proto:   newURL.Scheme,
+		addr:    addr,
+		baseURL: basePath,
+		HTTPCli: httpCli,
+		version: version,
+	}, nil
+}
+
+// generateTLSConfig configures TLS for API Client.
+func generateTLSConfig(host string, tls TLSConfig) *tls.Config {
+	// init tls config
+	if tls.Key != "" && tls.Cert != "" && !strings.HasPrefix(host, "unix://") {
+		tlsCfg, err := GenTLSConfig(tls.Key, tls.Cert, tls.CA)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fail to parse tls config %v", err)
+			os.Exit(1)
+		}
+		tlsCfg.InsecureSkipVerify = !tls.VerifyRemote
+
+		return tlsCfg
+	}
+	return nil
+}
+
+func generateBaseURL(u *url.URL, tls TLSConfig) string {
+	if tls.Key != "" && tls.Cert != "" && u.Scheme != "unix" {
+		return "https://" + u.Host
+	}
+
+	if u.Scheme == "unix" {
+		return "http://d"
+	}
+	return "http://" + u.Host
+}
+
+// BaseURL returns the base URL of APIClient
+func (client *APIClient) BaseURL() string {
+	return client.baseURL
+}
+
+// GetAPIPath returns the versioned request path to call the api.
+// It appends the query parameters to the path if they are not empty.
+func (client *APIClient) GetAPIPath(path string, query url.Values) string {
+	var apiPath string
+	if client.version != "" {
+		v := strings.TrimPrefix(client.version, "v")
+		apiPath = fmt.Sprintf("/v%s%s", v, path)
+	} else {
+		apiPath = path
+	}
+
+	u := url.URL{
+		Path: apiPath,
+	}
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+// UpdateClientVersion sets client version new value.
+func (client *APIClient) UpdateClientVersion(v string) {
+	client.version = v
+}

--- a/client/httputils.go
+++ b/client/httputils.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// UnixScheme is a scheme for unix.
+const UnixScheme = "unix"
+
+// TCPScheme is a scheme for TCP.
+const TCPScheme = "tcp"
+
+// HTTPScheme is a scheme for HTTP.
+const HTTPScheme = "http"
+
+// HTTPSScheme is a scheme for HTTPS.
+const HTTPSScheme = "https"
+
+// ParseHost inputs a host address string, and output four type:
+// url.URL, basePath, address without scheme and an error.
+func ParseHost(host string) (*url.URL, string, string, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	var basePath string
+	switch u.Scheme {
+	case UnixScheme:
+		basePath = "http://d"
+	case TCPScheme:
+		basePath = "http://" + u.Host
+	case HTTPScheme:
+		basePath = host
+	case HTTPSScheme:
+		basePath = host
+	default:
+		return nil, "", "", fmt.Errorf("not support url scheme %v", u.Scheme)
+	}
+
+	return u, basePath, strings.TrimPrefix(host, u.Scheme+"://"), nil
+}
+
+// GenTLSConfig returns a tls config object according to inputting parameters.
+func GenTLSConfig(key, cert, ca string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	tlsCert, err := tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read X509 key pair (cert: %q, key: %q): %v", cert, key, err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	if ca == "" {
+		return tlsConfig, nil
+	}
+
+	cp := x509.NewCertPool()
+	pem, err := ioutil.ReadFile(ca)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate %q: %v", ca, err)
+	}
+	if !cp.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", ca)
+	}
+	tlsConfig.ClientCAs = cp
+	return tlsConfig, nil
+}
+
+// NewHTTPClient creates a http client using url and tlsconfig
+func NewHTTPClient(u *url.URL, tlsConfig *tls.Config, dialTimeout time.Duration) *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	switch u.Scheme {
+	case UnixScheme:
+		unixDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.DialTimeout("unix", u.Path, dialTimeout)
+		}
+		tr.DialContext = unixDial
+	default:
+		dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, dialTimeout)
+		}
+		tr.DialContext = dial
+	}
+
+	return &http.Client{
+		Transport: tr,
+	}
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"context"
+
+	"github.com/alibaba/Dragonfly/apis/types"
+)
+
+// CommonAPIClient defines common methods of api client
+type CommonAPIClient interface {
+	PreheatAPIClient
+}
+
+// PreheatAPIClient defines methods of Container client.
+type PreheatAPIClient interface {
+	PreheatCreate(ctx context.Context, config *types.PreheatCreateRequest) (*types.PreheatCreateResponse, error)
+}

--- a/client/preheat_create.go
+++ b/client/preheat_create.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/alibaba/Dragonfly/apis/types"
+)
+
+// PreheatCreate creates a preheat task.
+func (client *APIClient) PreheatCreate(ctx context.Context, config *types.PreheatCreateRequest) (*types.PreheatCreateResponse, error) {
+	resp, err := client.post(ctx, "/preheats", nil, config, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	preheat := &types.PreheatCreateResponse{}
+
+	err = decodeBody(preheat, resp.Body)
+	ensureCloseReader(resp)
+
+	return preheat, err
+}

--- a/client/preheat_info.go
+++ b/client/preheat_info.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/alibaba/Dragonfly/apis/types"
+)
+
+// PreheatInfo get detailed information of a preheat task.
+func (client *APIClient) PreheatInfo(ctx context.Context, id string) (*types.PreheatInfo, error) {
+	resp, err := client.get(ctx, "/preheats/"+id, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	preheat := &types.PreheatInfo{}
+
+	err = decodeBody(preheat, resp.Body)
+	ensureCloseReader(resp)
+
+	return preheat, err
+}

--- a/client/preheat_list.go
+++ b/client/preheat_list.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/alibaba/Dragonfly/apis/types"
+)
+
+// PreheatList lists detailed information of preheat tasks.
+func (client *APIClient) PreheatList(ctx context.Context, id string) ([]*types.PreheatInfo, error) {
+	resp, err := client.get(ctx, "/preheats", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	preheats := []*types.PreheatInfo{}
+
+	err = decodeBody(preheats, resp.Body)
+	ensureCloseReader(resp)
+
+	return preheats, err
+}

--- a/client/request.go
+++ b/client/request.go
@@ -1,0 +1,179 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+// RespError defines the response error.
+type RespError struct {
+	code int
+	msg  string
+}
+
+// Error implements the error interface.
+func (e RespError) Error() string {
+	return e.msg
+}
+
+// Code returns the response  code
+func (e RespError) Code() int {
+	return e.code
+}
+
+// Response wraps the http.Response and other states.
+type Response struct {
+	StatusCode int
+	Status     string
+	Body       io.ReadCloser
+}
+
+func (client *APIClient) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (*Response, error) {
+	return client.sendRequest(ctx, "GET", path, query, nil, headers)
+}
+
+func (client *APIClient) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*Response, error) {
+	body, err := objectToJSONStream(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.sendRequest(ctx, "POST", path, query, body, headers)
+}
+
+func (client *APIClient) postRawData(ctx context.Context, path string, query url.Values, data io.Reader, headers map[string][]string) (*Response, error) {
+	return client.sendRequest(ctx, "POST", path, query, data, headers)
+}
+
+func (client *APIClient) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (*Response, error) {
+	return client.sendRequest(ctx, "DELETE", path, query, nil, headers)
+}
+
+func (client *APIClient) hijack(ctx context.Context, path string, query url.Values, obj interface{}, header map[string][]string) (net.Conn, *bufio.Reader, error) {
+	body, err := objectToJSONStream(obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := client.newRequest("POST", path, query, body, header)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "tcp")
+
+	req.Host = client.addr
+	conn, err := net.DialTimeout(client.proto, client.addr, defaultTimeout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	}
+
+	clientconn := httputil.NewClientConn(conn, nil)
+	defer clientconn.Close()
+
+	if _, err := clientconn.Do(req); err != nil {
+		return nil, nil, err
+	}
+
+	rwc, br := clientconn.Hijack()
+
+	return rwc, br, nil
+}
+
+func (client *APIClient) newRequest(method, path string, query url.Values, body io.Reader, header map[string][]string) (*http.Request, error) {
+	fullPath := client.baseURL + client.GetAPIPath(path, query)
+	req, err := http.NewRequest(method, fullPath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if header != nil {
+		for k, v := range header {
+			req.Header[k] = v
+		}
+	}
+
+	return req, err
+}
+
+func (client *APIClient) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (*Response, error) {
+	req, err := client.newRequest(method, path, query, body, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cancellableDo(ctx, client.HTTPCli, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, RespError{code: resp.StatusCode, msg: string(data)}
+	}
+
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       resp.Body,
+	}, nil
+}
+
+func cancellableDo(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	type contextResp struct {
+		response *http.Response
+		err      error
+	}
+
+	ctxResp := make(chan contextResp, 1)
+	go func() {
+		resp, err := client.Do(req)
+		ctxResp <- contextResp{
+			response: resp,
+			err:      err,
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		tr := client.Transport.(*http.Transport)
+		tr.CancelRequest(req)
+		<-ctxResp
+		return nil, ctx.Err()
+
+	case resp := <-ctxResp:
+		return resp.response, resp.err
+	}
+}
+
+func objectToJSONStream(obj interface{}) (io.Reader, error) {
+	if obj != nil {
+		b, err := json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(b), nil
+	}
+
+	return nil, nil
+}

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+func decodeBody(obj interface{}, body io.Reader) error {
+	if err := json.NewDecoder(body).Decode(obj); err != nil {
+		return fmt.Errorf("failed to decode body: %v", err)
+	}
+
+	return nil
+}
+
+func ensureCloseReader(resp *Response) {
+	if resp != nil && resp.Body != nil {
+		// close body ReadCloser to make Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When we expose API side of supernode in Dragonfly, caller should have a sdk to call API.

This pr adds preheat related golang sdk for client.

The API endpoints is:

* GET /preheats/{id}
* GET /preheats
* POST /preheats

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Will add in a follow-up


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

