### PR TITLE
chore: create links to clients in /usr/local/bin

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -19,7 +19,7 @@ BASE_HOME=$(cd "${curDir}"/.. && pwd)
 
 BUILD_DIR="${BASE_HOME}/build"
 
-INSTALL_PREFIX="${HOME}/.dragonfly"
+INSTALL_PREFIX="/opt/dragonfly"
 
 . "${BUILD_DIR}/log.sh"
 
@@ -32,16 +32,27 @@ printResult() {
         error "${filed}" "FAILURE"
     fi
 }
+
 buildClient() {
     field="dfdaemon&dfget"
     echo "====================================================================="
     info "${field}" "compiling dfdaemon and dfget..."
     cd "${BUILD_DIR}/client"
-    test -d "${INSTALL_PREFIX}" || mkdir -p "${INSTALL_PREFIX}"
     ./configure --prefix="${INSTALL_PREFIX}"
-    make && make install && export PATH=$PATH:${INSTALL_PREFIX}/df-client
+    make
     retCode=$?
-    make clean
+    printResult "${field}" ${retCode}
+    return ${retCode}
+}
+
+installClient() {
+    field="install client"
+    echo "====================================================================="
+    info "${field}" "install dfdaemon and dfget..."
+    cd "${BUILD_DIR}/client"
+    make install
+    retCode=$?
+    test ${retCode} -eq 0 && make clean
     printResult "${field}" ${retCode}
     return ${retCode}
 }
@@ -58,6 +69,9 @@ buildSupernode() {
 
 main() {
     case "$1" in
+        install)
+            installClient
+        ;;
         client)
             buildClient
         ;;

--- a/build/client/env.sh
+++ b/build/client/env.sh
@@ -23,7 +23,7 @@ export DRAGONFLY_HOME=${curDir%/build/client*}
 export BUILD_GOPATH=/tmp/dragonfly/build
 export BUILD_SOURCE_HOME="${BUILD_GOPATH}/src/github.com/alibaba/Dragonfly"
 
-export INSTALL_HOME="${HOME}/.dragonfly"
+export INSTALL_HOME="/opt/dragonfly"
 
 export CONFIGURED_VARIABLES_FILE="${BUILD_GOPATH}/configured_variables.sh"
 

--- a/build/client/run.sh
+++ b/build/client/run.sh
@@ -141,9 +141,17 @@ install() {
     # cp -r ${BIN_DIR}/${PKG_NAME}/*          ${installDir}
     cp "${BIN_DIR}"/${DFDAEMON_BINARY_NAME}   "${installDir}"
     cp "${BIN_DIR}"/${DFGET_BINARY_NAME}      "${installDir}"
+
+    createLink "${installDir}/${DFDAEMON_BINARY_NAME}" /usr/local/bin/dfdaemon
+    createLink "${installDir}/${DFGET_BINARY_NAME}" /usr/local/bin/dfget
 }
 
 uninstall() {
+    echo "unlink /usr/local/bin/dfdaemon"
+    test -e /usr/local/bin/dfdaemon && unlink /usr/local/bin/dfdaemon
+    echo "unlink /usr/local/bin/dfget"
+    test -e /usr/local/bin/dfget && unlink /usr/local/bin/dfget
+
     echo "uninstall dragonfly: ${INSTALL_HOME}"
     test -d "${INSTALL_HOME}" && rm -rf "${INSTALL_HOME}"
 }
@@ -156,6 +164,15 @@ clean() {
 #
 # =============================================================================
 #
+
+createLink() {
+    srcPath="$1"
+    linkPath="$2"
+
+    echo "create link ${linkPath} to ${srcPath}"
+    test -e "${linkPath}" && unlink "${linkPath}"
+    ln -s "${srcPath}" "${linkPath}"
+}
 
 createDir() {
     test -e "$1" && rm -rf "$1"


### PR DESCRIPTION
Signed-off-by: lowzj <zj3142063@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Create links `dfdaemon` and `dfget` in `/usr/local/bin`. It's convenient for users to use dragonfly client directly after installing. 
